### PR TITLE
Fixed - Some tests fail under Windows #12

### DIFF
--- a/survey/exporter/survey2x.py
+++ b/survey/exporter/survey2x.py
@@ -87,7 +87,7 @@ class Survey2X(object):
 
         LOGGER.debug("Exporting survey '%s' to %s", self.survey, self._get_X())
         try:
-            with open(self.file_name(), "w") as f:
+            with open(self.file_name(), "w", encoding="UTF-8") as f:
                 f.write(self.survey_to_x())
             LOGGER.info("Wrote %s in %s", self._get_X(), self.file_name())
         except IOError as exc:

--- a/survey/exporter/tex/configuration.py
+++ b/survey/exporter/tex/configuration.py
@@ -69,7 +69,7 @@ class Configuration(object):
 
         :param String filepath: The path of the yaml configuration file.
         :rtype: Dict """
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="UTF-8") as f:
             configuration = yaml.load(f)
         for survey_name in list(configuration.keys()):
             self.check_survey_exists(survey_name)

--- a/survey/exporter/tex/question2tex_sankey.py
+++ b/survey/exporter/tex/question2tex_sankey.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import platform
 
 from django.utils.translation import ugettext_lazy as _
 from pandas.core.frame import DataFrame
-from pySankey.sankey import sankey
 
 from survey.exporter.tex.question2tex import Question2Tex
 from survey.models.question import Question
+
+if platform.system() == "Windows":
+    from pySankey.sankey import sankey
+else:
+    from pysankey.sankey import sankey
 
 LOGGER = logging.getLogger(__name__)
 

--- a/survey/exporter/tex/question2tex_sankey.py
+++ b/survey/exporter/tex/question2tex_sankey.py
@@ -5,6 +5,7 @@ import platform
 
 from django.utils.translation import ugettext_lazy as _
 from pandas.core.frame import DataFrame
+from pysankey import sankey
 
 from survey.exporter.tex.question2tex import Question2Tex
 from survey.models.question import Question
@@ -73,26 +74,13 @@ class Question2TexSankey(Question2Tex):
                     q2.append(answer_to_q2)
         df = DataFrame(data={self.question.text: q1, other_question.text: q2})
         name = "tex/q{}_vs_q{}".format(self.question.pk, other_question.pk)
-        if platform.system() == "Windows":
-            from pySankey.sankey import sankey
-
-            sankey(
-                df[self.question.text],
-                df[other_question.text],
-                aspect=20,
-                fontsize=10,
-                figure_name=name,
-            )
-        else:
-            from pysankey.sankey import sankey
-
-            sankey(
-                df[self.question.text],
-                df[other_question.text],
-                aspect=20,
-                fontsize=10,
-                figureName=name,
-            )
+        sankey(
+            df[self.question.text],
+            df[other_question.text],
+            aspect=20,
+            fontsize=10,
+            figureName=name,
+        )
         return Question2TexSankey.TEX_SKELETON % (
             name[4:],
             self.question.pk,

--- a/survey/exporter/tex/question2tex_sankey.py
+++ b/survey/exporter/tex/question2tex_sankey.py
@@ -4,7 +4,7 @@ import logging
 
 from django.utils.translation import ugettext_lazy as _
 from pandas.core.frame import DataFrame
-from pysankey import sankey
+from pySankey.sankey import sankey
 
 from survey.exporter.tex.question2tex import Question2Tex
 from survey.models.question import Question
@@ -78,7 +78,7 @@ class Question2TexSankey(Question2Tex):
             df[other_question.text],
             aspect=20,
             fontsize=10,
-            figureName=name,
+            figure_name=name,
         )
         return Question2TexSankey.TEX_SKELETON % (
             name[4:],

--- a/survey/exporter/tex/question2tex_sankey.py
+++ b/survey/exporter/tex/question2tex_sankey.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import platform
 
 from django.utils.translation import ugettext_lazy as _
 from pandas.core.frame import DataFrame

--- a/survey/exporter/tex/question2tex_sankey.py
+++ b/survey/exporter/tex/question2tex_sankey.py
@@ -9,11 +9,6 @@ from pandas.core.frame import DataFrame
 from survey.exporter.tex.question2tex import Question2Tex
 from survey.models.question import Question
 
-if platform.system() == "Windows":
-    from pySankey.sankey import sankey
-else:
-    from pysankey.sankey import sankey
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -78,13 +73,26 @@ class Question2TexSankey(Question2Tex):
                     q2.append(answer_to_q2)
         df = DataFrame(data={self.question.text: q1, other_question.text: q2})
         name = "tex/q{}_vs_q{}".format(self.question.pk, other_question.pk)
-        sankey(
-            df[self.question.text],
-            df[other_question.text],
-            aspect=20,
-            fontsize=10,
-            figure_name=name,
-        )
+        if platform.system() == "Windows":
+            from pySankey.sankey import sankey
+
+            sankey(
+                df[self.question.text],
+                df[other_question.text],
+                aspect=20,
+                fontsize=10,
+                figure_name=name,
+            )
+        else:
+            from pysankey.sankey import sankey
+
+            sankey(
+                df[self.question.text],
+                df[other_question.text],
+                aspect=20,
+                fontsize=10,
+                figureName=name,
+            )
         return Question2TexSankey.TEX_SKELETON % (
             name[4:],
             self.question.pk,

--- a/survey/management/commands/generatetexconf.py
+++ b/survey/management/commands/generatetexconf.py
@@ -18,7 +18,7 @@ class Command(SurveyCommand):
         parser.add_argument("output", nargs="+", type=str, help="Output prefix.")
 
     def write_conf(self, name, conf):
-        file_ = open(name, "w")
+        file_ = open(name, "w", encoding="UTF-8")
         file_.write(str(conf))
         file_.close()
 

--- a/survey/tests/locale/test_locale_normalization.py
+++ b/survey/tests/locale/test_locale_normalization.py
@@ -11,26 +11,17 @@ class TestLocaleNormalization(unittest.TestCase):
     def test_normalization(self):
         """ We test if the messages were properly created with makemessages --no-obsolete --no-wrap. """
         if platform.system() == "Windows":
-            makemessages_command = [
-                "py",
-                "-3",
-                "manage.py",
-                "makemessages",
-                "--no-obsolete",
-                "--no-wrap",
-                "--ignore",
-                "venv",
-            ]
+            python_3 = ["py", "-3"]
         else:
-            makemessages_command = [
-                "python3",
-                "manage.py",
-                "makemessages",
-                "--no-obsolete",
-                "--no-wrap",
-                "--ignore",
-                "venv",
-            ]
+            python_3 = ["python3"]
+        makemessages_command = python_3 + [
+            "manage.py",
+            "makemessages",
+            "--no-obsolete",
+            "--no-wrap",
+            "--ignore",
+            "venv",
+        ]
         number_of_language = len(os.listdir(self.LOCALE_PATH))
         subprocess.check_call(makemessages_command)
         git_diff_command = ["git", "diff", self.LOCALE_PATH]

--- a/survey/tests/locale/test_locale_normalization.py
+++ b/survey/tests/locale/test_locale_normalization.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import unittest
+import platform
 
 
 class TestLocaleNormalization(unittest.TestCase):
@@ -9,15 +10,27 @@ class TestLocaleNormalization(unittest.TestCase):
 
     def test_normalization(self):
         """ We test if the messages were properly created with makemessages --no-obsolete --no-wrap. """
-        makemessages_command = [
-            "python3",
-            "manage.py",
-            "makemessages",
-            "--no-obsolete",
-            "--no-wrap",
-            "--ignore",
-            "venv",
-        ]
+        if platform.system() == "Windows":
+            makemessages_command = [
+                "py",
+                "-3",
+                "manage.py",
+                "makemessages",
+                "--no-obsolete",
+                "--no-wrap",
+                "--ignore",
+                "venv",
+            ]
+        else:
+            makemessages_command = [
+                "python3",
+                "manage.py",
+                "makemessages",
+                "--no-obsolete",
+                "--no-wrap",
+                "--ignore",
+                "venv",
+            ]
         number_of_language = len(os.listdir(self.LOCALE_PATH))
         subprocess.check_call(makemessages_command)
         git_diff_command = ["git", "diff", self.LOCALE_PATH]

--- a/survey/tests/management/commands/test_exportresult.py
+++ b/survey/tests/management/commands/test_exportresult.py
@@ -18,7 +18,7 @@ class TestExportresult(TestManagement):
         return os.path.join(settings.CSV_DIR, csv_name)
 
     def get_file_content(self, path):
-        file_ = open(path)
+        file_ = open(path, encoding="UTF-8")
         content = file_.read()
         file_.close()
         return content


### PR DESCRIPTION
## Issue number

#12 

## Description

This PR changes to pass all test on Windows.
In some tests the error was caused by `Command not found` or the absence of  `encoding = "UTF-8".
Therefore, I added `encoding = "UTF-8" in `open()` function.
And I added a logic of adding command on Windows using [Platform.system()](https://docs.python.org/2/library/platform.html#platform.system).

I have confirmed that all tests pass by this change except one.
It is `Check Yaml` in `pre-commit-hooks`'s test.
You can read detail of this reason [here](https://github.com/pre-commit/pre-commit-hooks/issues/377).
But it is resolved by [PR of `pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks/pull/378).
The test is going to be passed by taking [PR of `pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks/pull/378).