### PR TITLE
Fix - 'Settings' object missing attribute (#41)

### DIFF
--- a/survey/__init__.py
+++ b/survey/__init__.py
@@ -4,7 +4,7 @@ def set_default_settings():
         from . import settings as app_settings
 
         for setting in dir(app_settings):
-            if setting in ["CHOICES_SEPARATOR", "ROOT"]:
+            if setting == "CHOICES_SEPARATOR":
                 if not hasattr(settings, setting):
                     setattr(settings, setting, getattr(app_settings, setting))
     except ImportError:

--- a/survey/__init__.py
+++ b/survey/__init__.py
@@ -1,0 +1,14 @@
+def set_default_settings():
+    try:
+        from django.conf import settings
+        from . import settings as app_settings
+
+        for setting in dir(app_settings):
+            if setting in ["CHOICES_SEPARATOR", "ROOT"]:
+                if not hasattr(settings, setting):
+                    setattr(settings, setting, getattr(app_settings, setting))
+    except ImportError:
+        pass
+
+
+set_default_settings()

--- a/survey/tests/test_default_settings.py
+++ b/survey/tests/test_default_settings.py
@@ -1,19 +1,26 @@
 from survey.tests import BaseTest
 from django.test import override_settings
 from django.conf import settings
-from django.test import tag
 from survey import set_default_settings
+from survey.exporter.tex.survey2tex import Survey2Tex
 
 
-@tag("set")
 @override_settings()
 class TestDefaultSettings(BaseTest):
     def test_set_choices_separator(self):
         url = "/admin/survey/survey/1/change/"
         del settings.CHOICES_SEPARATOR
         self.login()
-        with self.assertRaises(AttributeError):
-            self.client.get(url)
         set_default_settings()
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        try:
+            self.client.get(url)
+        except AttributeError:
+            self.fail("AttributeError: survey failed to set CHOICES_SEPARATOR")
+
+    def test_set_root(self):
+        del settings.ROOT
+        set_default_settings()
+        try:
+            Survey2Tex.generate(self, "/")
+        except AttributeError:
+            self.fail("AttributeError: survey failed to set ROOT")

--- a/survey/tests/test_default_settings.py
+++ b/survey/tests/test_default_settings.py
@@ -1,0 +1,19 @@
+from survey.tests import BaseTest
+from django.test import override_settings
+from django.conf import settings
+from django.test import tag
+from survey import set_default_settings
+
+
+@tag("set")
+@override_settings()
+class TestDefaultSettings(BaseTest):
+    def test_set_choices_separator(self):
+        url = "/admin/survey/survey/1/change/"
+        del settings.CHOICES_SEPARATOR
+        self.login()
+        with self.assertRaises(AttributeError):
+            self.client.get(url)
+        set_default_settings()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/survey/tests/test_default_settings.py
+++ b/survey/tests/test_default_settings.py
@@ -2,7 +2,6 @@ from survey.tests import BaseTest
 from django.test import override_settings
 from django.conf import settings
 from survey import set_default_settings
-from survey.exporter.tex.survey2tex import Survey2Tex
 
 
 @override_settings()
@@ -16,11 +15,3 @@ class TestDefaultSettings(BaseTest):
             self.client.get(url)
         except AttributeError:
             self.fail("AttributeError: survey failed to set CHOICES_SEPARATOR")
-
-    def test_set_root(self):
-        del settings.ROOT
-        set_default_settings()
-        try:
-            getattr(settings, "ROOT")
-        except AttributeError:
-            self.fail("AttributeError: survey failed to set ROOT")

--- a/survey/tests/test_default_settings.py
+++ b/survey/tests/test_default_settings.py
@@ -21,6 +21,6 @@ class TestDefaultSettings(BaseTest):
         del settings.ROOT
         set_default_settings()
         try:
-            Survey2Tex.generate(self, "/")
+            getattr(settings, "ROOT")
         except AttributeError:
             self.fail("AttributeError: survey failed to set ROOT")


### PR DESCRIPTION
Hey there. The added code will set both "CHOICES_SEPARATOR" and "ROOT" when the package is initialized if they are not defined in the users settings.

My only concern is that the user's ROOT will be set to the same directory as the survey app. I've been looking through the code to see if this will cause any issues but couldn't find anything obvious. Please let me know if this will be an issue or if there are any other concerns.