### PR TITLE
Updated Configuration to remove YAMLLoadWarning:

### DIFF
--- a/survey/exporter/tex/configuration.py
+++ b/survey/exporter/tex/configuration.py
@@ -70,7 +70,7 @@ class Configuration(object):
         :param String filepath: The path of the yaml configuration file.
         :rtype: Dict """
         with open(filepath, "r", encoding="UTF-8") as f:
-            configuration = yaml.load(f)
+            configuration = yaml.save_load(f)
         for survey_name in list(configuration.keys()):
             self.check_survey_exists(survey_name)
             if not configuration[survey_name]:


### PR DESCRIPTION
without the fix the Warning 'exporter/tex/configuration.py:73: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.' is thrown.