### PR TITLE
Expiration date enhancement for post requests

### DIFF
--- a/survey/decorators.py
+++ b/survey/decorators.py
@@ -8,9 +8,7 @@ from survey.models import Survey
 
 def survey_available(func):
     """
-    Checks if a survey is available (published and not expired)
-    :param func:
-    :return:
+    Checks if a survey is available (published and not expired). Use this as a decorator for view functions.
     """
 
     @wraps(func)

--- a/survey/decorators.py
+++ b/survey/decorators.py
@@ -1,0 +1,29 @@
+from datetime import date
+from functools import wraps
+
+from django.shortcuts import Http404, get_object_or_404
+
+from survey.models import Survey
+
+
+def survey_available(func):
+    """
+    Checks if a survey is available (published and not expired)
+    :param func:
+    :return:
+    """
+
+    @wraps(func)
+    def survey_check(self, request, *args, **kwargs):
+        survey = get_object_or_404(
+            Survey.objects.prefetch_related("questions", "questions__category"), is_published=True, id=kwargs["id"]
+        )
+        if not survey.is_published:
+            raise Http404
+        if survey.expire_date < date.today():
+            raise Http404
+        if survey.publish_date > date.today():
+            raise Http404
+        return func(self, request, *args, **kwargs, survey=survey)
+
+    return survey_check

--- a/survey/tests/views/test_survey_detail.py
+++ b/survey/tests/views/test_survey_detail.py
@@ -128,6 +128,16 @@ class TestSurveyDetail(BaseTest):
         response = self.client.get(reverse("survey-detail", args=(7,)))
         self.assertEqual(response.status_code, 404)
 
+    def test_when_expiration_date_is_in_past_survey_is_not_visible_via_post(self):
+        """ when expiration_date is in the past the survey should be hidden for post requests """
+        response = self.client.post(reverse("survey-detail", args=(6,)))
+        self.assertEqual(response.status_code, 404)
+
+    def test_when_publication_date_is_in_future_survey_is_not_visible_via_post(self):
+        """ when publish_date is in the future the survey should be hidden for post requests """
+        response = self.client.post(reverse("survey-detail", args=(7,)))
+        self.assertEqual(response.status_code, 404)
+
     def test_the_survey_should_be_visible(self):
         """ when publish_date is in the past and expiration in the future
         the survey should be visible """


### PR DESCRIPTION
Hi, thanks for this cool project. I just found it and it is very suitable for a small project I am working on.

I studied the code a little and found the quite recent expiration date feature. I noticed that it only checks for expiration on the GET request, which means that it is still possible (for an attacker, spammer, troll, whatever) to send survey data even if it is not available.

The solution I wrote uses a decorator for that check so that there is no copy&pasted code in both, the get and the post function.

In order to reduce database calls, I decided to get the survey from the database inside the decorator and pass it to the underlying function as a keyword argument. Also, I added two tests regarding the post request check.  