### PR TITLE
Feature/filter sections survey

### DIFF
--- a/survey/admin.py
+++ b/survey/admin.py
@@ -13,6 +13,11 @@ class QuestionInline(admin.StackedInline):
     ordering = ("order", "category")
     extra = 1
 
+    def get_formset(self, request, obj, *args, **kwargs):
+        formset = super().get_formset(request, obj, *args, **kwargs)
+        formset.form.base_fields["category"].queryset = obj.categories.all()
+        return formset
+
 
 class CategoryInline(admin.TabularInline):
     model = Category

--- a/survey/admin.py
+++ b/survey/admin.py
@@ -15,7 +15,8 @@ class QuestionInline(admin.StackedInline):
 
     def get_formset(self, request, obj, *args, **kwargs):
         formset = super().get_formset(request, obj, *args, **kwargs)
-        formset.form.base_fields["category"].queryset = obj.categories.all()
+        if obj:
+            formset.form.base_fields["category"].queryset = obj.categories.all()
         return formset
 
 

--- a/survey/tests/admin/test_question.py
+++ b/survey/tests/admin/test_question.py
@@ -11,28 +11,15 @@ from survey.models.survey import Survey
 class TestQuestionInlineAdmin(TestCase):
     def setUp(self):
         self.survey = Survey.objects.create(
-            name="Survey One",
-            description="Survey's Description",
-            need_logged_user=False
+            name="Survey One", description="Survey's Description", need_logged_user=False
         )
         another_survey = Survey.objects.create(
-            name="Another Survey",
-            description="Another Survey's Description",
-            need_logged_user=False
+            name="Another Survey", description="Another Survey's Description", need_logged_user=False
         )
-        self.category_1 = Category.objects.create(
-            name="First Category",
-            survey=self.survey
-        )
-        self.category_2 = Category.objects.create(
-            name="Second Category",
-            survey=self.survey
-        )
+        self.category_1 = Category.objects.create(name="First Category", survey=self.survey)
+        self.category_2 = Category.objects.create(name="Second Category", survey=self.survey)
 
-        self.another_survey_category = Category.objects.create(
-            name="Another Survey Category",
-            survey=another_survey
-        )
+        self.another_survey_category = Category.objects.create(name="Another Survey Category", survey=another_survey)
 
         self.site = AdminSite()
         self.request = mock.Mock()

--- a/survey/tests/admin/test_question.py
+++ b/survey/tests/admin/test_question.py
@@ -1,0 +1,47 @@
+from unittest import mock
+
+from django.contrib.admin.sites import AdminSite
+from django.test import TestCase
+
+from survey.admin import QuestionInline
+from survey.models.category import Category
+from survey.models.survey import Survey
+
+
+class TestQuestionInlineAdmin(TestCase):
+    def setUp(self):
+        self.survey = Survey.objects.create(
+            name="Survey One",
+            description="Survey's Description",
+            need_logged_user=False
+        )
+        another_survey = Survey.objects.create(
+            name="Another Survey",
+            description="Another Survey's Description",
+            need_logged_user=False
+        )
+        self.category_1 = Category.objects.create(
+            name="First Category",
+            survey=self.survey
+        )
+        self.category_2 = Category.objects.create(
+            name="Second Category",
+            survey=self.survey
+        )
+
+        self.another_survey_category = Category.objects.create(
+            name="Another Survey Category",
+            survey=another_survey
+        )
+
+        self.site = AdminSite()
+        self.request = mock.Mock()
+
+    def test_question_admin_inline_filter_surveys_category(self):
+        question_admin = QuestionInline(Survey, self.site)
+        formset = question_admin.get_formset(self.request, self.survey)
+        qs = formset.form.base_fields["category"].queryset
+
+        self.assertEqual(qs.count(), 2)
+        self.assertNotIn(self.another_survey_category, qs)
+

--- a/survey/tests/admin/test_question.py
+++ b/survey/tests/admin/test_question.py
@@ -45,3 +45,13 @@ class TestQuestionInlineAdmin(TestCase):
         self.assertEqual(qs.count(), 2)
         self.assertNotIn(self.another_survey_category, qs)
 
+    def test_question_admin_inline_filter_no_surveys_yet(self):
+        self.survey.delete()
+        self.another_survey_category.delete()
+        self.survey = None
+
+        question_admin = QuestionInline(Survey, self.site)
+        formset = question_admin.get_formset(self.request, self.survey)
+        qs = formset.form.base_fields["category"].queryset
+
+        self.assertEqual(qs.count(), 0)


### PR DESCRIPTION
Hi, I've noticed that when we need to choose the `Category` for a `Question` in the admin interface, categories from other Surveys also appear in the dropdown menu.

I've made a small modification to filter the categories that don't belong to the current Survey.

## Before:
![Captura de Tela 2020-11-13 às 15 22 45](https://user-images.githubusercontent.com/2186646/99107137-233dc300-25c4-11eb-8b80-1d22404d9cb2.png)

## After:
![Captura de Tela 2020-11-13 às 15 21 44](https://user-images.githubusercontent.com/2186646/99107147-2a64d100-25c4-11eb-8e51-49d0760c0362.png)



[]s