### PR TITLE
default survey panel to open

### DIFF
--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -25,14 +25,14 @@
 				<div class="panel panel-default">
 				    <div class="panel-heading">
 				        <h3 class="panel-title"> <a
-				        data-toggle="collapse"
+				        data-toggle="collapse show"
 				        data-parent="#accordion"
 				        href="#collapse{{category.slugify}}">
 				            {% trans "Answer this part" %}
 			            </a></h3>
 				    </div>
                     <div class="category-container">
-				        <div id="collapse{{category.slugify}}" class="panel-collapse collapse {% if not survey.editable_answers and response_form.response is not None %}in{% endif %}
+				        <div id="collapse{{category.slugify}}" class="panel-collapse collapse show {% if not survey.editable_answers and response_form.response is not None %}in{% endif %}
 				        {{ response_form|collapse_form:category }}">
 				            <div class="panel-body">
 	                           {% include "survey/question.html" %}


### PR DESCRIPTION
A change to the display template has defaulted the category panels (using Bootstrap data-toggle) to "closed" and this has caused quite a bit of confusion to users of the survey in my site.  I get regular feedback along the lines of "there are no questions to answer."  It was also confusing to me for a short time until I realized "Answer this section" was actually a toggle to display the questions.

I am proposing this minor to change to default the panel to "open" so as to avoid this confusion.