### PR TITLE
Update README.md - Adding plugin to requirements.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The software is developed in english. Other available languages are :
 Add `django-survey-and-report` to your requirements and get it with pip.
 
 ~~~~bash
-echo 'django-survey-and-report' > requirements.txt
+echo 'django-survey-and-report' >> requirements.txt
 pip install -r requirements.txt
 ~~~~
 


### PR DESCRIPTION
It's a simple change, but the old line in README.md

    echo 'django-survey-and-report' > requirements.txt

will destroy any existing lines in `requirements.txt`

That's why I suggest using the `>>` operator, to add the line

    echo 'django-survey-and-report' >> requirements.txt