### PR TITLE
Made image template a class attribute rather than local

### DIFF
--- a/survey/widgets.py
+++ b/survey/widgets.py
@@ -4,6 +4,7 @@ from django.template.loader import render_to_string
 
 class ImageSelectWidget(forms.widgets.Widget):
     template_name = "survey/forms/image_select.html"
+
     class Media:
         js = (
             "http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js",

--- a/survey/widgets.py
+++ b/survey/widgets.py
@@ -3,6 +3,7 @@ from django.template.loader import render_to_string
 
 
 class ImageSelectWidget(forms.widgets.Widget):
+    template_name = "survey/forms/image_select.html"
     class Media:
         js = (
             "http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js",
@@ -11,12 +12,11 @@ class ImageSelectWidget(forms.widgets.Widget):
         )
 
     def render(self, name, value, *args, **kwargs):
-        template_name = "survey/forms/image_select.html"
         choices = []
         for index, choice in enumerate(self.choices):
             if choice[0] != "":
                 value, img_src = choice[0].split(":", 1)
                 choices.append({"img_src": img_src, "value": value, "full_value": choice[0], "index": index})
         context = {"name": name, "choices": choices}
-        html = render_to_string(template_name, context)
+        html = render_to_string(self.template_name, context)
         return html


### PR DESCRIPTION
This is the fix from issue 115 'ImageSelectWidget' object has no attribute 'template_name' -

This makes the template a class attribute instead.  This now allows you to add a survey question of type image_select without crashing the survey.