### PR TITLE
Added "viewport" meta tag to base template to fix scaling on mobile devices

### DIFF
--- a/survey/templates/survey/base.html
+++ b/survey/templates/survey/base.html
@@ -3,6 +3,7 @@
 <html lang="en">
   <head>
 	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>{% block title %}{% endblock title %}</title>
     <link rel="icon" href="{% static 'img/favicon.ico'%}"/>
     <link href="{% static 'survey/css/bootstrap.min.css'%}" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
When using django-survey on a phone I noticed that the text is too small and the elements are too wide. I noticed the "viewport" meta tag is missing when I compared the template code to the official Bootstrap getting started guide (see https://getbootstrap.com/docs/3.3/getting-started/#template). After adding the tag to the base template the scaling is fixed.