### PR TITLE
Add sty and yaml includes to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include survey *html *png *gif *js *jpg *jpeg *svg *py *po
+recursive-include survey *html *png *gif *js *jpg *jpeg *svg *py *po *sty *yaml


### PR DESCRIPTION
Without these includes, the default configuration for the tex exporter is missing from the installed package for `django-survey`, and the management commands to export to PDF fail.