### PR TITLE
Update the URL example code in the README to Django docs recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,7 @@ Add a URL entry to your project’s urls.py, for example:
 
 ```python
 from django.conf import settings
-from django.conf.urls import include
-
-try:
-    from django.conf.urls import url
-except ImportError:
-    # Django 4.0 replaced url by something else
-    # See https://stackoverflow.com/a/70319607/2519059
-    from django.urls import re_path as url
+from django.urls import include, path
 
 urlpatterns = [
     # Your own url pattern here
@@ -90,7 +83,7 @@ urlpatterns = [
 
 if 'survey' in settings.INSTALLED_APPS:
     urlpatterns += [
-        url(r'^survey/', include('survey.urls'))
+        path('survey/', include('survey.urls'))
     ]
 ```
 


### PR DESCRIPTION
The README includes an example URL configuration that supposes a Django version transitioning from pre 4.0 to post 4.0, which are no longer [supported versions]. This change updates the example to match the current [Django documentation] regarding including other URLconf modules to more closely match what users are likely to have in their `urls.py` files.

[supported versions]: https://www.djangoproject.com/download/#supported-versions
[Django documentation]: https://docs.djangoproject.com/en/5.2/topics/http/urls/#including-other-urlconfs